### PR TITLE
chore: add basic style example using bg-image

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ class App extends Component{
   
     render(){
         return (
-            <Particles params={{
+            <Particles 
+              params={{
             		particles: {
             			line_linked: {
             				shadow: {
@@ -65,7 +66,12 @@ class App extends Component{
             				}
             			}
             		}
-            	}}/>
+            	}}
+              style={
+                width: '100%',
+                backgroundImage: `url(${logo})` 
+              }
+            />
         );
     };
 


### PR DESCRIPTION
While the docs detail that there's a style prop, those not familiar with es6, particleJS, or how javascript uses camel-case for css, may find it difficult to effectively use the prop.

My update to the docs is my way of addressing all 3 of those above mentioned issues while still being easy to reason about--just adding a background image.