### PR TITLE
fix svg rending by initializing count_svg

### DIFF
--- a/src/lib/ParticlesLibrary.ts
+++ b/src/lib/ParticlesLibrary.ts
@@ -83,6 +83,7 @@ export default class ParticlesLibrary{
 			mode_bubble_size: this.params.interactivity.modes.bubble.size,
 			mode_repulse_distance: this.params.interactivity.modes.repulse.distance
 		};
+		tmp.count_svg = 0;
 	}
 
 


### PR DESCRIPTION
Currently, `count_svg` is not initialized and failing to pass the condition `if( tmp.count_svg >= particles.number.value ){` present in Vendors.ts.