### PR TITLE
A fix for issue #75 : switch to strict typescript

### DIFF
--- a/src/Particles.tsx
+++ b/src/Particles.tsx
@@ -43,21 +43,24 @@ export default class Particles extends Component<
 	}
 
 	private refresh(props: Readonly<ParticlesProps>): void {
-		if (this.state.canvas) {
+		const { canvas } = this.state;
+		if (canvas) {
 			this.destroy();
 			this.setState(
 				{
-					library: this.buildParticlesLibrary(props.params)
+					library: this.buildParticlesLibrary(props.params) || undefined
 				},
 				() => {
-					this.loadCanvas(this.state.canvas);
+					this.loadCanvas(canvas);
 				}
 			);
 		}
 	}
 
 	destroy() {
-		this.state.library.destroy();
+		if (this.state.library) {
+			this.state.library.destroy();
+		}
 	}
 
 	loadCanvas(canvas: HTMLCanvasElement) {
@@ -67,8 +70,12 @@ export default class Particles extends Component<
 					canvas
 				},
 				() => {
-					this.state.library.loadCanvas(this.state.canvas);
-					this.state.library.start();
+					const { library } = this.state;
+					if (!library) {
+						return;
+					}
+					library.loadCanvas(canvas);
+					library.start();
 				}
 			);
 		}
@@ -89,7 +96,7 @@ export default class Particles extends Component<
 
 	componentDidMount() {
 		this.setState({
-			library: this.buildParticlesLibrary(this.props.params)
+			library: this.buildParticlesLibrary(this.props.params) || undefined
 		});
 	}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
         "module": "commonjs",
         "target": "es6",
         "jsx": "react",
-        "removeComments": true
+        "removeComments": true,
+        "strict": true
     },
     "files": [
         "./src/index.ts"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const webpack = require( 'webpack' );
 
 const production = process.env.NODE_ENV === "production";
 
-const plugins = production ? 
+const plugins = production ?
 	[
 		new webpack.optimize.OccurrenceOrderPlugin(),
 		new webpack.DefinePlugin({
@@ -23,7 +23,8 @@ const typescriptLoader = {
                 presets: ['@babel/preset-env']
             }
         }, {
-            loader: 'ts-loader'
+            loader: 'ts-loader',
+            options: { compilerOptions: { strict: process.env.NODE_ENV !== 'production' }}
         }
     ]
 };
@@ -67,7 +68,7 @@ const config = {
                 root: "React"
             }
         }
-        
+
     ],
     plugins
 };


### PR DESCRIPTION
Issue #75 is caused by calling a method on a piece of state that's sometimes `undefined`. (In this case, it's caused by the line ```this.state.library.destroy();``` and ```this.state.library``` does not exist in some weird situations)

Using "strict" typescript should make these kind of things easier to detect.