### PR TITLE
webpack external tsParticles

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.11",
-    "tsparticles": "^1.12.7"
+    "tsparticles": "^1.12.8"
   },
   "peerDependencies": {
     "react": "^16.0.0"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,8 +73,8 @@ const config = {
                 amd: "react",
                 root: "React"
             }
-        }
-        
+        },
+        /ts[pP]articles/
     ],
     plugins
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3974,10 +3974,10 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
-tsparticles@^1.12.7:
-  version "1.12.7"
-  resolved "https://registry.yarnpkg.com/tsparticles/-/tsparticles-1.12.7.tgz#ceb31079004fb1f3ac40089e3cf3df6ceca7a960"
-  integrity sha512-z88R9QuXA8UBCeBY+ezntr6vweq/zUN8zaPZEJBJfE96ctZcg5AvYRIUQD4GfWAPaBjcIdM7viOsPQkynDgi+Q==
+tsparticles@^1.12.8:
+  version "1.12.8"
+  resolved "https://registry.yarnpkg.com/tsparticles/-/tsparticles-1.12.8.tgz#c538785239cf4c60d732fdb702a8de1e06260714"
+  integrity sha512-K4elNvfOeK1LQC9EuqtGu5BpVW1IQgCE+sJrXJfIPMU9e57e6kXQGUcBtx9N7mE5FApL7cmC4nVEdStEC8TK2Q==
   dependencies:
     pathseg "^1.2.0"
 


### PR DESCRIPTION
This reduces the `react-particles-js` bundle size to a bunch of kb, tsParticles will be used completely as a dependency instead of bundling it and having it installed too