### PR TITLE
Add the ability to reference particles container from parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ class App extends Component{
 | style | object | The style of the canvas element. |
 | className | string | The class name of the canvas wrapper. |
 | canvasClassName | string | the class name of the canvas. |
+| particlesRef | object | The instance of the [particles container](https://github.com/matteobruni/tsparticles/wiki/Particles-Container-class) |
 
 Find your parameters configuration [here](https://particles.matteobruni.it).
 

--- a/src/Particles.tsx
+++ b/src/Particles.tsx
@@ -16,6 +16,7 @@ export interface ParticlesProps {
     style: any;
     className?: string;
     canvasClassName?: string;
+    particlesRef?: React.RefObject<Container>
 }
 
 export interface ParticlesState {
@@ -55,6 +56,10 @@ export default class Particles extends Component<ParticlesProps,
 
         tsParticles.dom();
         const container = new Container(tagId, options);
+
+        if (this.props.particlesRef) {
+            (this.props.particlesRef as React.MutableRefObject<Container>).current = container;
+        }
 
         return container;
     }


### PR DESCRIPTION
In order to comply with [WCAG A requirements](https://www.w3.org/TR/WCAG21/#pause-stop-hide), I had to add a play/pause button to the particle effect on my website. However, I had no method of accessing the underlying Particles Container instance from this component. This PR adds that functionality and makes use of `refs` to easily add in a `ref.current.pause()` and `ref.current.play()` functionality to unblock my usage:

```jsx
const Comp = () => {
	const ref = React.useRef()

	const play = () => {
	    ref.current.play();
	}

	const pause = () => {
	    ref.current.pause();
	}

	return (
	  <Particles
	          height={"100vh"}
	          width={"100vw"}
	          className="particlesContainer"
	          params={particlesParams}
	          forwardRef={ref}
	        />
	)
}
```