### PR TITLE
Updated tsparticles peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
   },
   "peerDependencies": {
     "react": "^16.0.0",
-    "tsparticles": "^1.29.2"
+    "tsparticles": "<2.0.0"
   }
 }

--- a/src/DefaultOptions.ts
+++ b/src/DefaultOptions.ts
@@ -2,6 +2,9 @@ import { ClickMode, HoverMode, InteractivityDetect, MoveDirection, OutMode, Shap
 import { InlineArrangement as PolygonMaskInlineArrangement, Type as PolygonMaskType } from 'tsparticles/Plugins/PolygonMask/Enums';
 
 export const defaultParams: ISourceOptions = {
+    fullScreen: {
+        enable: false
+    },
     particles: {
         number: {
             value: 40,


### PR DESCRIPTION
Peer dependency updated to be prepared before tsParticles `v2` will be ready.
Added `FullScreen` default options to avoid issues with `1.37.0`